### PR TITLE
Add readline and introduce Command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+redox_liner = "0.5.1"

--- a/src/command.rs
+++ b/src/command.rs
@@ -99,6 +99,7 @@ impl<'a> std::convert::TryFrom<&'a [&'a str]> for Command<'a> {
 }
 
 #[cfg(test)]
+#[allow(clippy::shadow_unrelated)] // We don't mind shadowing here, so stop Clippy from complaining.
 mod tests {
     use super::*;
     use std::convert::TryFrom;

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,0 +1,201 @@
+#[derive(Debug, PartialEq)]
+/// Command that will be executed.
+pub enum Command<'a> {
+    /// Activates any updates in config for process/group.
+    Add(&'a [&'a str]),
+    /// Clear one or multiple process’ log files
+    Clear(&'a [&'a str]),
+    /// Exit TaskMaster.
+    Exit,
+    /// Get the PID of one or multiple child processes.
+    PID(&'a [&'a str]),
+    /// Removes process/group from active config.
+    Remove(&'a [&'a str]),
+    /// Reload the daemon’s configuration files, without add/remove (no restarts).
+    ReRead,
+    /// Restart multiple processes or groups.
+    /// Note: restart does not reread config files. For that, see `Reread` and `Update`.
+    Restart(&'a [&'a str]),
+    /// Start one or multiple processes/groups.
+    Start(&'a [&'a str]),
+    /// Get status on one or multiple named processes.
+    Status(&'a [&'a str]),
+    /// Stop one or multiple processes or groups.
+    Stop(&'a [&'a str]),
+    /// Reload config and add/remove as necessary, and will restart affected programs.
+    Update(&'a [&'a str]),
+}
+
+#[derive(Debug, PartialEq)]
+/// Errors that could appear when one tries to parse an input into a Command.
+pub enum ParsingError {
+    EmptyCommand,
+    UnknownCommand(String),
+    UnexpectedArguments,
+    MissingArguments,
+}
+
+impl ParsingError {
+    pub fn display(&self) {
+        match self {
+            Self::UnknownCommand(s) => eprintln!("Unknown command: {}", s),
+            Self::UnexpectedArguments => eprintln!("Unexpected arguments"),
+            Self::MissingArguments => eprintln!("Missing arguments"),
+            _ => {}
+        }
+    }
+}
+
+/// Creates a new `Command` based on the arguments provided.
+/// Example:
+/// ```rust
+/// create_command!(args, Exit, zero_args);
+/// ```
+/// Will create a `Command::Exit`, and will error if the number of
+/// additional arguments (after the first argument) is not 0.
+/// Possible values are: zero_args, multiple_args, unspecified.
+macro_rules! create_command {
+    ($args:ident, $name:ident, zero_args) => {
+        if $args.len() == 1 {
+            Ok(Command::$name)
+        } else {
+            Err(ParsingError::UnexpectedArguments)
+        }
+    };
+    ($args:ident, $name:ident, multiple_args) => {
+        if $args.len() > 1 {
+            Ok(Command::$name(&$args[1..]))
+        } else {
+            Err(ParsingError::MissingArguments)
+        }
+    };
+    ($args:ident, $name:ident, unspecified) => {
+        Ok(Command::$name(&$args[1..]))
+    };
+}
+
+impl<'a> std::convert::TryFrom<&'a [&'a str]> for Command<'a> {
+    type Error = ParsingError;
+
+    fn try_from(args: &'a [&'a str]) -> Result<Self, Self::Error> {
+        match args.get(0) {
+            None => Err(Self::Error::EmptyCommand),
+            Some(&command) => match command {
+                "add" => create_command!(args, Add, multiple_args),
+                "clear" => create_command!(args, Clear, multiple_args),
+                "exit" => create_command!(args, Exit, zero_args),
+                "pid" => create_command!(args, PID, unspecified),
+                "remove" => create_command!(args, Remove, multiple_args),
+                "reread" => create_command!(args, ReRead, zero_args),
+                "restart" => create_command!(args, Restart, multiple_args),
+                "start" => create_command!(args, Start, multiple_args),
+                "status" => create_command!(args, Status, unspecified),
+                "stop" => create_command!(args, Stop, multiple_args),
+                "update" => create_command!(args, Update, multiple_args),
+                other => Err(Self::Error::UnknownCommand(other.into())),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::convert::TryFrom;
+
+    #[test]
+    fn empty_line() {
+        let args: &[&str] = &[];
+        let res = Command::try_from(args);
+        assert_eq!(res, Err(ParsingError::EmptyCommand));
+    }
+
+    #[test]
+    fn unknwon_command() {
+        let args: &[&str] = &["42"];
+        let res = Command::try_from(args);
+        assert_eq!(
+            res,
+            Err(ParsingError::UnknownCommand(args[0].into()))
+        );
+    }
+
+    #[test]
+    fn typo() {
+        let args: &[&str] = &["addd"];
+        let res = Command::try_from(args);
+        assert_eq!(
+            res,
+            Err(ParsingError::UnknownCommand(args[0].into()))
+        );
+    }
+
+    #[test]
+    fn zero_args_command() {
+        let args: &[&str] = &["exit"];
+        let res = Command::try_from(args);
+        assert!(res.is_ok());
+
+        let args: &[&str] = &["exit", "123"];
+        let res = Command::try_from(args);
+        assert_eq!(res, Err(ParsingError::UnexpectedArguments));
+    }
+
+    #[test]
+    fn multiple_args_command() {
+        let args: &[&str] = &["clear"];
+        let res = Command::try_from(args);
+        assert_eq!(res, Err(ParsingError::MissingArguments));
+
+        let args: &[&str] = &["clear", "123"];
+        let res = Command::try_from(args);
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn unspecified() {
+        let args: &[&str] = &["pid"];
+        let res = Command::try_from(args);
+        assert!(res.is_ok());
+
+        let args: &[&str] = &["pid", "123"];
+        let res = Command::try_from(args);
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn one_arg_unspecified() {
+        let args: &[&str] = &["pid", "cat"];
+        let res = Command::try_from(args);
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn two_args_unspecified() {
+        let args: &[&str] = &["status", "cat", "nginx"];
+        let res = Command::try_from(args);
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn supported_commands() {
+        let lines: &[&[&str]] = &[
+            &["add", "cat"],
+            &["clear", "python"],
+            &["exit"],
+            &["pid", "cat"],
+            &["remove", "cat"],
+            &["reread"],
+            &["restart", "cat"],
+            &["start", "cat"],
+            &["status", "cat", "nginx", "top"],
+            &["stop", "cat", "nginx"],
+            &["update", "cat", "ft_server"],
+        ];
+        for &line in lines {
+            let res = Command::try_from(line);
+            dbg!(&res);
+            assert!(res.is_ok());
+        }
+    }
+}

--- a/src/command.rs
+++ b/src/command.rs
@@ -114,20 +114,14 @@ mod tests {
     fn unknwon_command() {
         let args: &[&str] = &["42"];
         let res = Command::try_from(args);
-        assert_eq!(
-            res,
-            Err(ParsingError::UnknownCommand(args[0].into()))
-        );
+        assert_eq!(res, Err(ParsingError::UnknownCommand(args[0].into())));
     }
 
     #[test]
     fn typo() {
         let args: &[&str] = &["addd"];
         let res = Command::try_from(args);
-        assert_eq!(
-            res,
-            Err(ParsingError::UnknownCommand(args[0].into()))
-        );
+        assert_eq!(res, Err(ParsingError::UnknownCommand(args[0].into())));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-extern crate liner;
 mod command;
 mod config;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,8 +19,10 @@ enum Command<'a> {
     PID(&'a [&'a str]),
     /// Removes process/group from active config.
     Remove(&'a [&'a str]),
+    /// Reload the daemon’s configuration files, without add/remove (no restarts).
+    ReRead,
     /// Restart multiple processes or groups.
-    /// Note: restart does not reread config files. For that, see reread and update.
+    /// Note: restart does not reread config files. For that, see `Reread` and `Update`.
     Restart(&'a [&'a str]),
     /// Start one or multiple processes/groups.
     Start(&'a [&'a str]),
@@ -98,6 +100,7 @@ impl<'a> std::convert::TryFrom<&'a [&'a str]> for Command<'a> {
                 "exit" => create_command!(data, Exit, zero_arg),
                 "pid" => create_command!(data, PID, multiple_args),
                 "remove" => create_command!(data, Remove, multiple_args),
+                "reread" => create_command!(data, ReRead, zero_arg),
                 "restart" => create_command!(data, Restart, multiple_args),
                 "start" => create_command!(data, Start, multiple_args),
                 "status" => create_command!(data, Status, one_arg),

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,145 @@ use config::Config;
 use std::convert::TryFrom;
 use std::path::Path;
 
+extern crate liner;
+use liner::{Completer, Context};
+
+struct EmptyCompleter;
+
+impl Completer for EmptyCompleter {
+    fn completions(&mut self, _start: &str) -> Vec<String> {
+        Vec::new()
+    }
+}
+
+#[derive(Debug)]
+enum Command<'a> {
+    Clear(&'a [&'a str]),
+    ClearAll,
+    Exit,
+    Restart(&'a [&'a str]),
+    RestartAll,
+    Start(&'a [&'a str]),
+    StartAll,
+    Status,
+    Stop(&'a [&'a str]),
+    StopAll,
+    Update,
+    UpdateAll,
+}
+
+#[derive(Debug)]
+enum CommandError {
+    EmptyCommand,
+    UnknownCommand(String),
+    UnexpectedArguments,
+    MissingArguments,
+}
+
+impl CommandError {
+    fn display(&self) {
+        match self {
+            Self::UnknownCommand(s) => eprintln!("{}", s),
+            Self::UnexpectedArguments => eprintln!("Unexpected arguments."),
+            Self::MissingArguments => eprintln!("Missing arguments."),
+            _ => {},
+        }
+    }
+}
+
+impl<'a> std::convert::TryFrom<&'a [&'a str]> for Command<'a> {
+    type Error = CommandError;
+
+    // TODO add a macro to avoid code duplication
+    fn try_from(data: &'a [&'a str]) -> Result<Self, Self::Error> {
+        match data.get(0) {
+            Some(&command) => match command {
+                "clear" => {
+                    if data[1..].is_empty() {
+                        Err(Self::Error::MissingArguments)
+                    } else if data[1] == "all" {
+                        Ok(Self::ClearAll)
+                    } else {
+                        Ok(Self::Clear(&data[1..]))
+                    }
+                }
+                "exit" => {
+                    if data[1..].is_empty() {
+                        Ok(Self::Exit)
+                    } else {
+                        Err(Self::Error::UnexpectedArguments)
+                    }
+                }
+                "restart" => {
+                    if data[1..].is_empty() {
+                        Err(Self::Error::MissingArguments)
+                    } else if data[1] == "all" {
+                        Ok(Self::RestartAll)
+                    } else {
+                        Ok(Self::Restart(&data[1..]))
+                    }
+                }
+                "start" => {
+                    if data[1..].is_empty() {
+                        Err(Self::Error::MissingArguments)
+                    } else if data[1] == "all" {
+                        Ok(Self::StartAll)
+                    } else {
+                        Ok(Self::Start(&data[1..]))
+                    }
+                }
+                "status" => {
+                    if data[1..].is_empty() {
+                        Ok(Self::Status)
+                    } else {
+                        Err(Self::Error::UnexpectedArguments)
+                    }
+                }
+                "stop" => {
+                    if data[1..].is_empty() {
+                        Err(Self::Error::MissingArguments)
+                    } else if data[1] == "all" {
+                        Ok(Self::StopAll)
+                    } else {
+                        Ok(Self::Stop(&data[1..]))
+                    }
+                }
+                "update" => {
+                    if data[1..].is_empty() {
+                        Ok(Self::Update)
+                    } else if data[1] == "all" {
+                        Ok(Self::UpdateAll)
+                    } else {
+                        Err(Self::Error::UnexpectedArguments)
+                    }
+                }
+                other => Err(Self::Error::UnknownCommand(format!(
+                    "Unknown command: {}",
+                    other
+                ))),
+            },
+            None => Err(Self::Error::EmptyCommand),
+        }
+    }
+}
+
 fn main() -> Result<(), std::io::Error> {
     let path = Path::new("config.yaml");
-    let config = Config::try_from(path)?;
-    println!("Here's your config: {:#?}", config);
+    let _config = Config::try_from(path)?;
+    let mut con = Context::new();
+
+    loop {
+        let res = con.read_line("$ ", None, &mut EmptyCompleter)?;
+
+        let words = res.split_ascii_whitespace().collect::<Vec<&str>>();
+        let cmd = Command::try_from(&words[..]);
+        match cmd {
+            Ok(Command::Exit) => break,
+            Ok(_) => {},
+            Err(cmd_err) => cmd_err.display(),
+        }
+
+        con.history.push(res.into())?;
+    }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,119 +1,12 @@
 extern crate liner;
+mod command;
 mod config;
 
+use command::Command;
 use config::Config;
 use liner::{Completer, Context};
 use std::convert::TryFrom;
 use std::path::Path;
-
-#[derive(Debug)]
-/// Command that will be executed.
-enum Command<'a> {
-    /// Activates any updates in config for process/group.
-    Add(&'a [&'a str]),
-    /// Clear one or multiple process’ log files
-    Clear(&'a [&'a str]),
-    /// Exit TaskMaster.
-    Exit,
-    /// Get the PID of one or multiple child processes.
-    PID(&'a [&'a str]),
-    /// Removes process/group from active config.
-    Remove(&'a [&'a str]),
-    /// Reload the daemon’s configuration files, without add/remove (no restarts).
-    ReRead,
-    /// Restart multiple processes or groups.
-    /// Note: restart does not reread config files. For that, see `Reread` and `Update`.
-    Restart(&'a [&'a str]),
-    /// Start one or multiple processes/groups.
-    Start(&'a [&'a str]),
-    /// Get status on one or multiple named processes.
-    Status(&'a str),
-    /// Stop one or multiple processes or groups.
-    Stop(&'a [&'a str]),
-    /// Reload config and add/remove as necessary, and will restart affected programs.
-    Update(&'a [&'a str]),
-}
-
-#[derive(Debug)]
-/// Errors that could appear when one tries to parse an input into a Command.
-enum CommandParsingError {
-    EmptyCommand,
-    UnknownCommand(String),
-    UnexpectedArguments,
-    MissingArguments,
-}
-
-impl CommandParsingError {
-    fn display(&self) {
-        match self {
-            Self::UnknownCommand(s) => eprintln!("{}", s),
-            Self::UnexpectedArguments => eprintln!("Unexpected arguments"),
-            Self::MissingArguments => eprintln!("Missing arguments"),
-            _ => {}
-        }
-    }
-}
-
-/// Creates a new `Command` based on the arguments provided.
-/// Example:
-/// ```rust
-/// create_command!(args, Exit, zero_arg);
-/// ```
-/// Will create a `Command::Exit`, and will error if the number of
-/// additional arguments (after the first argument) is not 0.
-/// Possible values are: zero_arg, one_arg, multiple_args.
-macro_rules! create_command {
-    ($args:ident, $name:ident, zero_arg) => {
-        if $args.len() == 1 {
-            Ok(Command::$name)
-        } else {
-            Err(CommandParsingError::UnexpectedArguments)
-        }
-    };
-    ($args:ident, $name:ident, one_arg) => {
-        if $args.len() == 2 {
-            Ok(Command::$name($args[1]))
-        } else if $args.len() < 2 {
-            Err(CommandParsingError::MissingArguments)
-        } else {
-            Err(CommandParsingError::UnexpectedArguments)
-        }
-    };
-    ($args:ident, $name:ident, multiple_args) => {
-        if $args.len() > 1 {
-            Ok(Command::$name(&$args[1..]))
-        } else {
-            Err(CommandParsingError::MissingArguments)
-        }
-    };
-}
-
-impl<'a> std::convert::TryFrom<&'a [&'a str]> for Command<'a> {
-    type Error = CommandParsingError;
-
-    fn try_from(data: &'a [&'a str]) -> Result<Self, Self::Error> {
-        match data.get(0) {
-            None => Err(Self::Error::EmptyCommand),
-            Some(&command) => match command {
-                "add" => create_command!(data, Add, multiple_args),
-                "clear" => create_command!(data, Clear, multiple_args),
-                "exit" => create_command!(data, Exit, zero_arg),
-                "pid" => create_command!(data, PID, multiple_args),
-                "remove" => create_command!(data, Remove, multiple_args),
-                "reread" => create_command!(data, ReRead, zero_arg),
-                "restart" => create_command!(data, Restart, multiple_args),
-                "start" => create_command!(data, Start, multiple_args),
-                "status" => create_command!(data, Status, one_arg),
-                "stop" => create_command!(data, Stop, multiple_args),
-                "update" => create_command!(data, Update, multiple_args),
-                other => Err(Self::Error::UnknownCommand(format!(
-                    "Unknown command: {}",
-                    other
-                ))),
-            },
-        }
-    }
-}
 
 /// Placeholder struct for Completer.
 struct EmptyCompleter;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,118 @@
+extern crate liner;
 mod config;
 
 use config::Config;
+use liner::{Completer, Context};
 use std::convert::TryFrom;
 use std::path::Path;
 
-extern crate liner;
-use liner::{Completer, Context};
+#[derive(Debug)]
+/// Command that will be executed.
+enum Command<'a> {
+    /// Activates any updates in config for process/group.
+    Add(&'a [&'a str]),
+    /// Clear one or multiple process’ log files
+    Clear(&'a [&'a str]),
+    /// Exit TaskMaster.
+    Exit,
+    /// Get the PID of one or multiple child processes.
+    PID(&'a [&'a str]),
+    /// Removes process/group from active config.
+    Remove(&'a [&'a str]),
+    /// Restart multiple processes or groups.
+    /// Note: restart does not reread config files. For that, see reread and update.
+    Restart(&'a [&'a str]),
+    /// Start one or multiple processes/groups.
+    Start(&'a [&'a str]),
+    /// Get status on one or multiple named processes.
+    Status(&'a str),
+    /// Stop one or multiple processes or groups.
+    Stop(&'a [&'a str]),
+    /// Reload config and add/remove as necessary, and will restart affected programs.
+    Update(&'a [&'a str]),
+}
 
+#[derive(Debug)]
+/// Errors that could appear when one tries to parse an input into a Command.
+enum CommandParsingError {
+    EmptyCommand,
+    UnknownCommand(String),
+    UnexpectedArguments,
+    MissingArguments,
+}
+
+impl CommandParsingError {
+    fn display(&self) {
+        match self {
+            Self::UnknownCommand(s) => eprintln!("{}", s),
+            Self::UnexpectedArguments => eprintln!("Unexpected arguments"),
+            Self::MissingArguments => eprintln!("Missing arguments"),
+            _ => {}
+        }
+    }
+}
+
+/// Creates a new `Command` based on the arguments provided.
+/// Example:
+/// ```rust
+/// create_command!(args, Exit, zero_arg);
+/// ```
+/// Will create a `Command::Exit`, and will error if the number of
+/// additional arguments (after the first argument) is not 0.
+/// Possible values are: zero_arg, one_arg, multiple_args.
+macro_rules! create_command {
+    ($args:ident, $name:ident, zero_arg) => {
+        if $args.len() == 1 {
+            Ok(Command::$name)
+        } else {
+            Err(CommandParsingError::UnexpectedArguments)
+        }
+    };
+    ($args:ident, $name:ident, one_arg) => {
+        if $args.len() == 2 {
+            Ok(Command::$name($args[1]))
+        } else if $args.len() < 2 {
+            Err(CommandParsingError::MissingArguments)
+        } else {
+            Err(CommandParsingError::UnexpectedArguments)
+        }
+    };
+    ($args:ident, $name:ident, multiple_args) => {
+        if $args.len() > 1 {
+            Ok(Command::$name(&$args[1..]))
+        } else {
+            Err(CommandParsingError::MissingArguments)
+        }
+    };
+}
+
+impl<'a> std::convert::TryFrom<&'a [&'a str]> for Command<'a> {
+    type Error = CommandParsingError;
+
+    fn try_from(data: &'a [&'a str]) -> Result<Self, Self::Error> {
+        match data.get(0) {
+            None => Err(Self::Error::EmptyCommand),
+            Some(&command) => match command {
+                "add" => create_command!(data, Add, multiple_args),
+                "clear" => create_command!(data, Clear, multiple_args),
+                "exit" => create_command!(data, Exit, zero_arg),
+                "pid" => create_command!(data, PID, multiple_args),
+                "remove" => create_command!(data, Remove, multiple_args),
+                "restart" => create_command!(data, Restart, multiple_args),
+                "start" => create_command!(data, Start, multiple_args),
+                "status" => create_command!(data, Status, one_arg),
+                "stop" => create_command!(data, Stop, multiple_args),
+                "update" => create_command!(data, Update, multiple_args),
+                other => Err(Self::Error::UnknownCommand(format!(
+                    "Unknown command: {}",
+                    other
+                ))),
+            },
+        }
+    }
+}
+
+/// Placeholder struct for Completer.
 struct EmptyCompleter;
 
 impl Completer for EmptyCompleter {
@@ -15,134 +121,24 @@ impl Completer for EmptyCompleter {
     }
 }
 
-#[derive(Debug)]
-enum Command<'a> {
-    Clear(&'a [&'a str]),
-    ClearAll,
-    Exit,
-    Restart(&'a [&'a str]),
-    RestartAll,
-    Start(&'a [&'a str]),
-    StartAll,
-    Status,
-    Stop(&'a [&'a str]),
-    StopAll,
-    Update,
-    UpdateAll,
-}
-
-#[derive(Debug)]
-enum CommandError {
-    EmptyCommand,
-    UnknownCommand(String),
-    UnexpectedArguments,
-    MissingArguments,
-}
-
-impl CommandError {
-    fn display(&self) {
-        match self {
-            Self::UnknownCommand(s) => eprintln!("{}", s),
-            Self::UnexpectedArguments => eprintln!("Unexpected arguments."),
-            Self::MissingArguments => eprintln!("Missing arguments."),
-            _ => {},
-        }
-    }
-}
-
-impl<'a> std::convert::TryFrom<&'a [&'a str]> for Command<'a> {
-    type Error = CommandError;
-
-    // TODO add a macro to avoid code duplication
-    fn try_from(data: &'a [&'a str]) -> Result<Self, Self::Error> {
-        match data.get(0) {
-            Some(&command) => match command {
-                "clear" => {
-                    if data[1..].is_empty() {
-                        Err(Self::Error::MissingArguments)
-                    } else if data[1] == "all" {
-                        Ok(Self::ClearAll)
-                    } else {
-                        Ok(Self::Clear(&data[1..]))
-                    }
-                }
-                "exit" => {
-                    if data[1..].is_empty() {
-                        Ok(Self::Exit)
-                    } else {
-                        Err(Self::Error::UnexpectedArguments)
-                    }
-                }
-                "restart" => {
-                    if data[1..].is_empty() {
-                        Err(Self::Error::MissingArguments)
-                    } else if data[1] == "all" {
-                        Ok(Self::RestartAll)
-                    } else {
-                        Ok(Self::Restart(&data[1..]))
-                    }
-                }
-                "start" => {
-                    if data[1..].is_empty() {
-                        Err(Self::Error::MissingArguments)
-                    } else if data[1] == "all" {
-                        Ok(Self::StartAll)
-                    } else {
-                        Ok(Self::Start(&data[1..]))
-                    }
-                }
-                "status" => {
-                    if data[1..].is_empty() {
-                        Ok(Self::Status)
-                    } else {
-                        Err(Self::Error::UnexpectedArguments)
-                    }
-                }
-                "stop" => {
-                    if data[1..].is_empty() {
-                        Err(Self::Error::MissingArguments)
-                    } else if data[1] == "all" {
-                        Ok(Self::StopAll)
-                    } else {
-                        Ok(Self::Stop(&data[1..]))
-                    }
-                }
-                "update" => {
-                    if data[1..].is_empty() {
-                        Ok(Self::Update)
-                    } else if data[1] == "all" {
-                        Ok(Self::UpdateAll)
-                    } else {
-                        Err(Self::Error::UnexpectedArguments)
-                    }
-                }
-                other => Err(Self::Error::UnknownCommand(format!(
-                    "Unknown command: {}",
-                    other
-                ))),
-            },
-            None => Err(Self::Error::EmptyCommand),
-        }
-    }
-}
-
 fn main() -> Result<(), std::io::Error> {
     let path = Path::new("config.yaml");
     let _config = Config::try_from(path)?;
+
     let mut con = Context::new();
 
     loop {
-        let res = con.read_line("$ ", None, &mut EmptyCompleter)?;
+        let line = con.read_line("$ ", None, &mut EmptyCompleter)?;
 
-        let words = res.split_ascii_whitespace().collect::<Vec<&str>>();
-        let cmd = Command::try_from(&words[..]);
+        let args = line.split_ascii_whitespace().collect::<Vec<&str>>();
+        let cmd = Command::try_from(&args[..]);
         match cmd {
             Ok(Command::Exit) => break,
-            Ok(_) => {},
+            Ok(_) => {} // We will need to actually execute the command here!
             Err(cmd_err) => cmd_err.display(),
         }
 
-        con.history.push(res.into())?;
+        con.history.push(line.into())?;
     }
     Ok(())
 }


### PR DESCRIPTION
## What this PR does
- Adds the `redox_liner` crate to use `liner()` (Rust's `readline()` equivalent).
- Introduces the `Command` struct (used when the user types `status` or `start`.
- Adds decent parsing for `Command`.
- Adds unit-tests for `Command`.

## Additional info
I would ask the reviewer to checkout on this branch and make sure to thoroughly test the code :)
